### PR TITLE
Removes unnecessary recursion

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -490,7 +490,6 @@ export default class MaterialTable extends React.Component {
             selectedRows.push(row);
           }
 
-          row.tableData.childRows && findSelecteds(row.tableData.childRows);
         });
       };
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -489,7 +489,6 @@ export default class MaterialTable extends React.Component {
           if (row.tableData.checked) {
             selectedRows.push(row);
           }
-
         });
       };
 


### PR DESCRIPTION
Within `onSelectionChange` the function `findSelecteds` calls itself to parse the current nodes children; This is not necessary because the method is parsing the original data which contains all data points in a flat structure. Removing this line stop the onSelectionChange event from returning duplicate rows.

## Description
Fixes a bug that returns duplicate rows are reported by `onSelectionChange` when using tree based data.

## Impacted Areas in Application
`MaterialTable.onSelectionChange` event 