### PR TITLE
Add custom text functions for exporting non-text columns in csv

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -35,14 +35,14 @@ export class MTableToolbar extends React.Component {
     const dataToExport = this.props.exportAllData ? this.props.data : this.props.renderData;
     const data = dataToExport.map(rowData =>
       columns.map(columnDef => {
-        return this.props.getFieldValue(rowData, columnDef);
+        return columnDef.getValueAsText ? columnDef.getValueAsText(rowData) : this.props.getFieldValue(rowData, columnDef);
       })
     );
 
     const builder = new CsvBuilder((this.props.exportFileName || this.props.title || 'data') + '.csv');
     builder
       .setDelimeter(this.props.exportDelimiter)
-      .setColumns(columns.map(columnDef => columnDef.title))
+      .setColumns(columns.map(columnDef => columnDef.titleAsText ? columnDef.titleAsText() : columnDef.title))
       .addRows(data)
       .exportFile();
   }

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -49,7 +49,9 @@ export const propTypes = {
     searchable: PropTypes.bool,
     sorting: PropTypes.bool,
     title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-    type: PropTypes.oneOf(['string', 'boolean', 'numeric', 'date', 'datetime', 'time', 'currency'])
+    type: PropTypes.oneOf(['string', 'boolean', 'numeric', 'date', 'datetime', 'time', 'currency']),
+    titleAsText: PropTypes.func,
+    getValueAsText: PropTypes.func
   })).isRequired,
   components: PropTypes.shape({
     Action: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -133,6 +133,8 @@ export interface Column<RowData extends object> {
   title?: string | React.ReactElement<any>;
   tooltip?: string;
   type?: ('boolean' | 'numeric' | 'date' | 'datetime' | 'time' | 'currency');
+  titleAsText?: () => string;
+  getValueAsText?: (data: RowData) => string;
 }
 
 export interface Components {


### PR DESCRIPTION
## Related Issue
Implements #2 

## Description
This feature will facilitate users an easy way to provide a text representation for non-text columns, in order to use it in CSV export and maybe elsewhere in the future

## Impacted Areas in Application
List general components of the application that this PR will affect:

- Default CSV Export function